### PR TITLE
Update: Add working_directory to Docker config

### DIFF
--- a/docker-spin-up/action.yml
+++ b/docker-spin-up/action.yml
@@ -89,6 +89,7 @@ runs:
         env_variables: ${{ steps.merge_docker_variables.outputs.variables }}
         env_file_stub: .env.dist
         env_file: .env
+        working_directory: ${{ inputs.working_directory }}
 
     - name: Update hosts file
       run: sudo echo "127.0.0.1 ${{ inputs.hostname }}" | sudo tee -a /etc/hosts

--- a/merge-environment-variables/action.yml
+++ b/merge-environment-variables/action.yml
@@ -2,7 +2,7 @@ name: Merge environment variables
 
 inputs:
   variables1:
-    description: 'JSON string representiing object with the neivnronment variables.'
+    description: 'JSON string representiing object with the environment variables.'
     required: true
   variables2:
     description: 'JSON string representing object with replacements.'


### PR DESCRIPTION
Currently Spin-up docker CI job is failing when called from any path that is not the default working directory. The reason is because this workflow is using another common CI job "Prepare Docker config" but is not passing the working_directory into that job. We need to provide it as an argument. 